### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-next.yml
+++ b/.github/workflows/docker-next.yml
@@ -1,4 +1,6 @@
 name: Build and Push Docker Image for Next.js App
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/gamerbeaker007/splinter-lands-next/security/code-scanning/1](https://github.com/gamerbeaker007/splinter-lands-next/security/code-scanning/1)

The best way to fix this problem is to add an explicit `permissions` block at the top level of the workflow YAML file (directly under the `name` or before `jobs`), or at the job level if finer control is required. Since all jobs in this workflow appear to require only basic read access to repository contents (to check out code), setting `permissions: contents: read` at the root level is appropriate and sufficient. No other write permissions (such as for issues or pull-requests) appear to be needed, since there are no steps in the job that would perform those actions.

To implement this, add the following lines to `.github/workflows/docker-next.yml` after the `name` field and before any job or `on:`/`env:` fields:

```yaml
permissions:
  contents: read
```

No new imports, methods, or definitions are needed, as this is a pure configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
